### PR TITLE
fix: desktop standalone server layout and WebSerial port handling

### DIFF
--- a/electron/server.ts
+++ b/electron/server.ts
@@ -31,12 +31,62 @@ async function findFreePort(preferred: number): Promise<number> {
   });
 }
 
+/**
+ * Find server.js under a standalone root. Handles both the normal layout
+ * (standalone/server.js) and the nested layout Next can emit when the project
+ * path includes segments like ~/src/... (standalone/src/<project>/server.js).
+ * postbuild should flatten this; this is a defensive fallback for electron:dev.
+ */
+function findStandaloneServerJs(standaloneRoot: string): string | null {
+  const direct = path.join(standaloneRoot, "server.js");
+  if (fs.existsSync(direct)) return direct;
+
+  function walk(dir: string, depth: number): string | null {
+    if (depth > 6) return null;
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(dir);
+    } catch {
+      return null;
+    }
+    for (const name of entries) {
+      if (name === "node_modules" || name === ".next" || name === "public") continue;
+      const child = path.join(dir, name);
+      let st: fs.Stats;
+      try {
+        st = fs.statSync(child);
+      } catch {
+        continue;
+      }
+      if (!st.isDirectory()) continue;
+      const candidate = path.join(child, "server.js");
+      if (fs.existsSync(candidate)) return candidate;
+      const nested = walk(child, depth + 1);
+      if (nested) return nested;
+    }
+    return null;
+  }
+
+  return walk(standaloneRoot, 0);
+}
+
 /** Resolve path to the standalone server.js. */
 function getServerPath(): string {
-  if (app.isPackaged) {
-    return path.join(process.resourcesPath, "standalone", "server.js");
-  }
-  return path.join(__dirname, "..", ".next", "standalone", "server.js");
+  const standaloneRoot = app.isPackaged
+    ? path.join(process.resourcesPath, "standalone")
+    : path.join(__dirname, "..", ".next", "standalone");
+
+  const found = findStandaloneServerJs(standaloneRoot);
+  if (found) return found;
+
+  // Default expected path (best error message if missing entirely)
+  return path.join(standaloneRoot, "server.js");
+}
+
+/** Working directory for the forked standalone server (parent of server.js). */
+function getServerCwd(): string {
+  const serverPath = getServerPath();
+  return path.dirname(serverPath);
 }
 
 /** Get the static files directory (for diagnostic logging only). */
@@ -122,12 +172,22 @@ export async function startServer(options: StartOptions = {}): Promise<number> {
     }
   }
 
+  if (!fs.existsSync(serverPath)) {
+    throw new Error(
+      `Standalone server not found at ${serverPath}. ` +
+        `Run "npm run build" first (postbuild flattens .next/standalone).`,
+    );
+  }
+
+  const serverCwd = getServerCwd();
+  console.log(`[electron] Starting standalone server: ${serverPath} (cwd=${serverCwd})`);
+
   serverProcess = fork(serverPath, [], {
     env,
     stdio: "pipe",
-    cwd: app.isPackaged
-      ? path.join(process.resourcesPath, "standalone")
-      : path.join(__dirname, ".."),
+    // Cwd must be the directory that contains server.js (and node_modules),
+    // not the monorepo root — especially when output is still nested.
+    cwd: serverCwd,
   });
 
   serverProcess.stdout?.on("data", (data: Buffer) => {

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,16 @@
 import type { NextConfig } from "next";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Pin tracing root to this package. Without it, repos under paths like
+// ~/src/ADOSMissionControl can emit standalone output nested as
+// .next/standalone/src/ADOSMissionControl/ — which breaks electron/server.ts
+// and electron-builder (they expect server.js at the standalone root).
+const projectRoot = path.dirname(fileURLToPath(import.meta.url));
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  outputFileTracingRoot: projectRoot,
   env: {
     CESIUM_BASE_URL: "/cesium/",
     NEXT_PUBLIC_BUILD_TARGET: process.env.NEXT_PUBLIC_BUILD_TARGET || "",

--- a/scripts/copy-standalone-assets.mjs
+++ b/scripts/copy-standalone-assets.mjs
@@ -1,5 +1,6 @@
 /**
- * Copy the runtime assets that Next.js `output: "standalone"` does not bundle.
+ * Copy the runtime assets that Next.js `output: "standalone"` does not bundle,
+ * and normalize the standalone layout for Electron / electron-builder.
  *
  * The standalone build emits a self-contained server under `.next/standalone/`
  * but intentionally leaves out `.next/static/` (hashed client chunks) and
@@ -7,13 +8,18 @@
  * 404, so the page renders its server HTML but never hydrates. The Electron
  * desktop wrapper runs this standalone server, so it needs both trees copied in.
  *
+ * Next.js may also nest the traced server under a path that mirrors the
+ * absolute project location (e.g. `.next/standalone/src/ADOSMissionControl/`
+ * when the repo lives at `~/src/ADOSMissionControl`). Desktop packaging and
+ * electron/server.ts expect `server.js` at the standalone root; we flatten here.
+ *
  * Runs as `postbuild`, so every `next build` (including the desktop scripts)
  * leaves `.next/standalone/` complete. No-op when standalone output is absent.
  *
  * @license GPL-3.0-only
  */
 
-import { cpSync, existsSync, rmSync } from "node:fs";
+import { cpSync, existsSync, readdirSync, rmSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 const root = process.cwd();
@@ -23,6 +29,71 @@ if (!existsSync(standalone)) {
   console.log("[standalone] .next/standalone not found — skipping (output:standalone not built)");
   process.exit(0);
 }
+
+/**
+ * Find a nested directory containing server.js (Next standalone output).
+ * Walks shallowly under standalone/ so we don't scan node_modules trees.
+ */
+function findNestedServerDir(dir, depth = 0) {
+  if (depth > 6) return null;
+  const direct = join(dir, "server.js");
+  if (existsSync(direct)) return dir;
+
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return null;
+  }
+
+  for (const name of entries) {
+    if (name === "node_modules" || name === ".next" || name === "public") continue;
+    const child = join(dir, name);
+    try {
+      if (!statSync(child).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    const found = findNestedServerDir(child, depth + 1);
+    if (found) return found;
+  }
+  return null;
+}
+
+/**
+ * If server.js is not at the standalone root, promote the nested project dir
+ * so electron/server.ts and afterPack see the conventional layout.
+ */
+function normalizeStandaloneLayout() {
+  const rootServer = join(standalone, "server.js");
+  if (existsSync(rootServer)) {
+    console.log("[standalone] server.js already at standalone root");
+    return;
+  }
+
+  const nested = findNestedServerDir(standalone);
+  if (!nested || nested === standalone) {
+    console.warn("[standalone] WARNING: could not locate server.js under .next/standalone");
+    return;
+  }
+
+  console.log(`[standalone] flattening nested output: ${nested} -> ${standalone}`);
+
+  const tmp = join(root, ".next", "standalone-flatten-tmp");
+  rmSync(tmp, { recursive: true, force: true });
+  cpSync(nested, tmp, { recursive: true });
+  rmSync(standalone, { recursive: true, force: true });
+  cpSync(tmp, standalone, { recursive: true });
+  rmSync(tmp, { recursive: true, force: true });
+
+  if (!existsSync(join(standalone, "server.js"))) {
+    console.warn("[standalone] WARNING: flatten completed but server.js still missing at root");
+  } else {
+    console.log("[standalone] flattened successfully (server.js + node_modules at root)");
+  }
+}
+
+normalizeStandaloneLayout();
 
 const copies = [
   { src: join(root, ".next", "static"), dst: join(standalone, ".next", "static") },

--- a/src/components/connect/DirectMavlinkPanel.tsx
+++ b/src/components/connect/DirectMavlinkPanel.tsx
@@ -98,8 +98,11 @@ export function DirectMavlinkPanel({ onClose }: { onClose: () => void }) {
           ? { baudRate: detail as number }
           : { url: detail as string }),
       });
+      // Direct connect does not need the modal afterward; main dashboard shows
+      // the new fleet row (via node registry attach in addDrone).
+      onClose();
     },
-    [],
+    [onClose],
   );
 
   function handleSerialConnected(name: string, _type: "serial", baudRate: number) {

--- a/src/lib/protocol/transport/webserial.ts
+++ b/src/lib/protocol/transport/webserial.ts
@@ -40,6 +40,58 @@ export class WebSerialTransport implements Transport {
   }
 
   /**
+   * Best-effort close of a port that may still be open from a previous
+   * Electron/Chrome session (orphan app, crash, connect dialog without disconnect).
+   * Web Serial only allows one open handle; failing to close first surfaces as
+   * "Failed to open serial port" / port in use.
+   */
+  private static async ensurePortClosed(port: SerialPort): Promise<void> {
+    try {
+      // readable/writable present means the port is open in this renderer.
+      if (port.readable || port.writable) {
+        await port.close().catch(() => {});
+      }
+    } catch {
+      // ignore — open() will throw a clearer error if still locked elsewhere
+    }
+  }
+
+  private static formatOpenError(err: unknown): Error {
+    const msg = err instanceof Error ? err.message : String(err);
+    const lower = msg.toLowerCase();
+    if (
+      lower.includes("failed to open") ||
+      lower.includes("already open") ||
+      lower.includes("access denied") ||
+      lower.includes("networkerror")
+    ) {
+      return new Error(
+        `${msg} — serial port is usually held by another app (another Electron/Altnautica window, Chrome/Edge tab, Mission Planner, QGC, Betaflight Configurator). ` +
+          `Quit those, or in this app disconnect first; then fully quit Electron (not just reload) and retry.`,
+      );
+    }
+    return err instanceof Error ? err : new Error(msg);
+  }
+
+  private async openPortStreams(baudRate: number): Promise<void> {
+    if (!this.port) throw new Error("No serial port");
+    await WebSerialTransport.ensurePortClosed(this.port);
+    try {
+      await this.port.open({ baudRate });
+    } catch (err) {
+      throw WebSerialTransport.formatOpenError(err);
+    }
+    this._connected = true;
+    if (this.port.readable) {
+      this.reader = this.port.readable.getReader();
+    }
+    if (this.port.writable) {
+      this.writer = this.port.writable.getWriter();
+    }
+    this.readLoop();
+  }
+
+  /**
    * Open the browser serial port picker and connect.
    * @param baudRate — UART baud rate, default 115200 (standard for MAVLink)
    */
@@ -56,30 +108,11 @@ export class WebSerialTransport implements Transport {
 
     try {
       this.port = await navigator.serial.requestPort();
-
-      // Port may still be open from a previous session (e.g. page refresh).
-      // Close it first so we can reopen cleanly with the desired baud rate.
-      if (this.port.readable) {
-        await this.port.close().catch(() => {});
-      }
-
-      await this.port.open({ baudRate });
-      this._connected = true;
-
-      // Set up read/write streams
-      if (this.port.readable) {
-        this.reader = this.port.readable.getReader();
-      }
-      if (this.port.writable) {
-        this.writer = this.port.writable.getWriter();
-      }
-
-      // Start reading in background
-      this.readLoop();
+      await this.openPortStreams(baudRate);
     } catch (err) {
       this._connected = false;
       this.port = null;
-      throw err;
+      throw err instanceof Error ? err : WebSerialTransport.formatOpenError(err);
     }
   }
 
@@ -94,28 +127,11 @@ export class WebSerialTransport implements Transport {
 
     try {
       this.port = port;
-
-      // Port may still be open from a previous session (e.g. page refresh).
-      // Close it first so we can reopen cleanly with the desired baud rate.
-      if (port.readable) {
-        await port.close().catch(() => {});
-      }
-
-      await this.port.open({ baudRate });
-      this._connected = true;
-
-      if (this.port.readable) {
-        this.reader = this.port.readable.getReader();
-      }
-      if (this.port.writable) {
-        this.writer = this.port.writable.getWriter();
-      }
-
-      this.readLoop();
+      await this.openPortStreams(baudRate);
     } catch (err) {
       this._connected = false;
       this.port = null;
-      throw err;
+      throw err instanceof Error ? err : WebSerialTransport.formatOpenError(err);
     }
   }
 


### PR DESCRIPTION
## Summary

Hardens the **Electron/desktop standalone** path when the repo lives under a traced parent path (e.g. `~/src/...`), and improves **WebSerial** connect/disconnect ergonomics for direct USB MAVLink.

**In scope (5 files):**
- `next.config.ts` — pin `outputFileTracingRoot` so standalone output is not nested under the monorepo path
- `scripts/copy-standalone-assets.mjs` — flatten nested `.next/standalone` and copy static/public assets after build
- `electron/server.ts` — resolve `server.js` from root or nested paths; fork with the correct cwd
- `src/lib/protocol/transport/webserial.ts` — release held ports cleanly; clearer errors when another app owns the device
- `src/components/connect/DirectMavlinkPanel.tsx` — close the connect modal after a successful direct link

**Out of scope / already on `main`:**
- Direct-FC fleet row registration (`attachFc` / `detachFc` in `drone-manager`) — landed in `dde9f440`; this change does not redo that work.

**Follow-up (separate branch, not in this PR):**
- `chore/vscode-desktop-launch` — VS Code `launch.json` / `tasks.json` for `desktop:dev` debugging only.

## Why

Desktop builds failed with missing/wrong `server.js` when Next traced the standalone output under a parent of the project dir. Operators also hit opaque WebSerial failures when Electron and Chrome both tried to hold the same USB port.

## Verification (CONTRIBUTING)

| Check | Result |
|-------|--------|
| `npm run lint` | Pass (exit 0; 0 errors, 170 pre-existing warnings repo-wide; no new errors in touched files) |
| `npm run build` | Pass — compiled, TypeScript clean; postbuild `[standalone] server.js already at standalone root` + static/public copied |
| `npm run demo` | Not required for this diff (no UI/demo engine changes); recommend smoke if reviewing connect modal only |
| Real hardware | WebSerial/desktop USB path — operator smoke on macOS recommended (see test plan) |
| Version bump | Not touched |

## Test plan

- [ ] `npm run build` — completes; postbuild reports standalone root + asset copy (no `server.js` ENOENT at runtime)
- [ ] `npm run desktop:dev` (or packaged desktop) — app loads without standalone/server path errors
- [ ] Direct connect (WebSerial) in desktop — connect succeeds; connect modal closes on success
- [ ] Only one of Electron vs Chrome holds the serial port; if the other tries, error is actionable (not a silent hang)
- [ ] Disconnect direct connect — port is released for reuse
- [ ] Optional: `npm run demo` smoke — dashboard unaffected

## Notes for reviewers

- Focused fix PR only; VS Code ergonomics intentionally split to `davidbitton:chore/vscode-desktop-launch` if wanted separately.
